### PR TITLE
Hotfix FindZeroValues

### DIFF
--- a/Kernel/ReductionTools/CategorifiabilityCriteria.m
+++ b/Kernel/ReductionTools/CategorifiabilityCriteria.m
@@ -45,7 +45,7 @@ CSPCValue[acc_][ring_FusionRing] :=
       Catch[
         Do[
           If[
-            Re[ Echo @
+            Re[ 
               N[
                 s = Sum[ chars[[ j1, i ]] chars[[ j2, i ]] chars[[ j3, i ]] / chars[[ 1, i ]], { i, r } ] ,
                 { Infinity, acc }
@@ -53,7 +53,7 @@ CSPCValue[acc_][ring_FusionRing] :=
             ] < 0,
 
             (* THEN *)
-            If[ Im[s] == 0, Throw[s] ];
+            If[ Im[s] == 0, Throw @ s ];
           ],
           { j1, r }, { j2, r }, { j3, r }
         ];

--- a/Kernel/ReductionTools/FindZeroValues.m
+++ b/Kernel/ReductionTools/FindZeroValues.m
@@ -94,11 +94,9 @@ FindZeroValues[ eqns_, vars_, opts:OptionsPattern[] ] :=
 
         replaceTrivialVars = ReplaceAll[ Dispatch @ Thread[ trivialVars -> 1 ] ];
 
-        reducedMats = 
+        reducedMats =
           WithMinimumDimension[ reducedMats, 2 ] // 
           replaceTrivialVars;
-
-        reducedERules = MapAt[ replaceTrivialVars, simpleERules, {All,2} ];
 
         If[
           MemberQ[False] @ PermanentConditions @ reducedMats,
@@ -106,8 +104,14 @@ FindZeroValues[ eqns_, vars_, opts:OptionsPattern[] ] :=
           Throw @ { }
         ];
 
+        reducedERules = 
+          MapAt[ replaceTrivialVars, simpleERules, {All,2} ];
+
         reducedVars = 
-          DeleteCases[1] @ Union @ Values @ reducedERules;
+          DeleteCases[1] @ 
+          Union @ 
+          replaceTrivialVars @ 
+          (simpleVars/.reducedERules);
 
         If[ 
           Length[reducedVars] === 0
@@ -128,12 +132,12 @@ FindZeroValues[ eqns_, vars_, opts:OptionsPattern[] ] :=
         (* Convert the equations to a proposition *)
         preProp = 
           And[
-            EqnsToProp[ ReplaceTrivialVars[ binEqns/.dEquiv] ],
+            EqnsToProp[ replaceTrivialVars[binEqns/.dEquiv] ],
             AddOptions[opts][SumEqnsToProp][ sumEqns, properEquivalences, trivialVars, b ],
             MatsToProposition[b] @ reducedMats/.dEquiv
           ]/.b[i_]:>i;
 
-        If[ preProp =!= True, preProp = DeleteDuplicates[preProp] ];
+        If[ preProp =!= True, preProp = DeleteDuplicates @ preProp ];
 
         printlog[ "FZV:preProp", { procID, preProp } ];
 
@@ -159,10 +163,10 @@ FindZeroValues[ eqns_, vars_, opts:OptionsPattern[] ] :=
             }, 
             Select[ Not @* Last ] @ 
             MapAt[ 
-              ReplaceAll[rules], 
+              ReplaceAll[rules],
               Join[ 
                 knowns,
-                properEquivalences
+                Thread[ reducedVars -> (reducedVars/.properEquivalences) ]
               ], 
               { All, 2 } 
             ]

--- a/PacletInfo.m
+++ b/PacletInfo.m
@@ -1,7 +1,7 @@
 PacletObject[<|
   "Name" -> "Anyonica"
   ,
-  "Version" -> "0.9.20.0"
+  "Version" -> "0.9.20.1"
   ,
   "Extensions" ->
     {


### PR DESCRIPTION
FindZeroValues works again if you don't give it tetrahedral symmetries.